### PR TITLE
use of java.util.Deque instead of java.util.Stack

### DIFF
--- a/src/main/java/org/xembly/DomStack.java
+++ b/src/main/java/org/xembly/DomStack.java
@@ -29,8 +29,9 @@
  */
 package org.xembly;
 
-import java.util.EmptyStackException;
-import java.util.Stack;
+import java.util.Deque;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -46,8 +47,8 @@ final class DomStack implements Directive.Stack {
     /**
      * Queue of pointers.
      */
-    private final transient Stack<Directive.Pointer> ptrs =
-        new Stack<Directive.Pointer>();
+    private final transient Deque<Directive.Pointer> ptrs =
+        new ConcurrentLinkedDeque<Directive.Pointer>();
 
     @Override
     public void push(final Directive.Pointer ptr) {
@@ -58,7 +59,7 @@ final class DomStack implements Directive.Stack {
     public Directive.Pointer pop() throws ImpossibleModificationException {
         try {
             return this.ptrs.pop();
-        } catch (final EmptyStackException ex) {
+        } catch (final NoSuchElementException ex) {
             throw new ImpossibleModificationException(
                 "stack is empty, can't POP", ex
             );

--- a/src/test/java/org/xembly/DomStackTest.java
+++ b/src/test/java/org/xembly/DomStackTest.java
@@ -63,4 +63,13 @@ public final class DomStackTest {
         );
     }
 
+    /**
+     * DomStack throws ImpossibleModificationException when
+     * trying to pop an empty stack.
+     * @throws Exception If some problem inside
+     */
+    @Test(expected = ImpossibleModificationException.class)
+    public void throwsExceptionOnEmpty() throws Exception {
+        new DomStack().pop();
+    }
 }


### PR DESCRIPTION
As stated in the java.util.Stack [javadoc](https://docs.oracle.com/javase/7/docs/api/java/util/Stack.html), we should prefer the use of java.util.Deque instead of java.util.Stack.

Since Stack is a thread safe data structure, I replace Stack with a ConcurrentLinkedDeque which is thread safe too. Nevertheless, looking at the code where DomStack is used, I'm not sure whether DomStack really needs to be thread safe.
Maybe could we improve performance by using an ArrayDeque ?

Please note Deque has been added with java 6. If your library needs to be java 5 compliant, then my PR will break java 5 compatibility. (is there still anybody using java 5 nowadays ???)

I updated the unit test accordingly. 
Thanks for taking time to review.