### PR TITLE
Ability to directly append an XML to Directives

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-xml</artifactId>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-xml</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/org/xembly/Directives.java
+++ b/src/main/java/org/xembly/Directives.java
@@ -260,6 +260,7 @@ public final class Directives implements Iterable<Directive> {
      * @return This object
      * @see #append(java.lang.Iterable)
      * @see Directives#copyOf(org.w3c.dom.Node)
+     * @since 0.23
      */
     public Directives append(final Node node) {
         return this.append(Directives.copyOf(node));

--- a/src/main/java/org/xembly/Directives.java
+++ b/src/main/java/org/xembly/Directives.java
@@ -29,7 +29,6 @@
  */
 package org.xembly;
 
-import com.jcabi.xml.XML;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -256,14 +255,14 @@ public final class Directives implements Iterable<Directive> {
     }
 
     /**
-     * Appends the {@link XML xml}.
-     * @param xml The xml to append
+     * Appends the {@link Node node}.
+     * @param node The node to append
      * @return This object
      * @see #append(java.lang.Iterable)
      * @see Directives#copyOf(org.w3c.dom.Node)
      */
-    public Directives append(final XML xml) {
-        return this.append(Directives.copyOf(xml.node()));
+    public Directives append(final Node node) {
+        return this.append(Directives.copyOf(node));
     }
 
     /**

--- a/src/main/java/org/xembly/Directives.java
+++ b/src/main/java/org/xembly/Directives.java
@@ -29,6 +29,7 @@
  */
 package org.xembly;
 
+import com.jcabi.xml.XML;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -252,6 +253,17 @@ public final class Directives implements Iterable<Directive> {
         }
         this.all.addAll(list);
         return this;
+    }
+
+    /**
+     * Appends the {@link XML xml}.
+     * @param xml The xml to append
+     * @return This object
+     * @see #append(java.lang.Iterable)
+     * @see Directives#copyOf(org.w3c.dom.Node)
+     */
+    public Directives append(final XML xml) {
+        return this.append(Directives.copyOf(xml.node()));
     }
 
     /**

--- a/src/test/java/org/xembly/DirectivesTest.java
+++ b/src/test/java/org/xembly/DirectivesTest.java
@@ -215,6 +215,36 @@ public final class DirectivesTest {
     }
 
     /**
+     * Directives can copy an existing XML.
+     * @throws Exception If some problem inside
+     * @since 1.0
+     */
+    @Test
+    public void copiesExistingXml() throws Exception {
+        final Document dom = DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder().newDocument();
+        new Xembler(
+            new Directives().add("guys").append(
+                new XMLDocument(
+                    StringUtils.join(
+                        "<joe name='Joey'><first/><second/>",
+                        "<io a='x'><f><name>\u20ac</name></f></io>",
+                        "<x><![CDATA[hey you]]></x>  </joe>"
+                    )
+                )
+            )
+        ).apply(dom);
+        MatcherAssert.assertThat(
+            XhtmlMatchers.xhtml(dom),
+            XhtmlMatchers.hasXPaths(
+                "/guys/joe[@name = 'Joey']",
+                "/guys/joe[first and second]",
+                "/guys/joe/io[@a='x']/f[name='\u20ac']"
+            )
+        );
+    }
+
+    /**
      * Directives can understand case.
      * @throws Exception If some problem inside
      * @since 0.14.1

--- a/src/test/java/org/xembly/DirectivesTest.java
+++ b/src/test/java/org/xembly/DirectivesTest.java
@@ -215,12 +215,12 @@ public final class DirectivesTest {
     }
 
     /**
-     * Directives can copy an existing XML.
+     * Appends an existing node.
      * @throws Exception If some problem inside
      * @since 1.0
      */
     @Test
-    public void copiesExistingXml() throws Exception {
+    public void appendsExistingNode() throws Exception {
         final Document dom = DocumentBuilderFactory.newInstance()
             .newDocumentBuilder().newDocument();
         new Xembler(
@@ -231,7 +231,7 @@ public final class DirectivesTest {
                         "<io a='x'><f><name>\u20ac</name></f></io>",
                         "<x><![CDATA[hey you]]></x>  </joe>"
                     )
-                )
+                ).node()
             )
         ).apply(dom);
         MatcherAssert.assertThat(


### PR DESCRIPTION
This PR solves the following problem:

**Cannot append and `XML` to `Directives` without dropping the high-level abstractions afforded by `Xembly` and `jcabi-xml`.** 

Take a look at [this](https://github.com/llorllale/loggit-maven-plugin/blob/207c36c69f70c9103c91d487223a6e4d61035db2/src/main/java/org/llorllale/mvn/plgn/loggit/DefaultLog.java#L75) example. It would be much nicer if I can just directly append an existing `XML` into `Directives`.