### PR TITLE
#82 XpathFactory moved to ThreadLocal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,50 +250,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>coveralls</id>
-            <activation>
-                <file><exists>pom.xml</exists></file>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>cobertura-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>site</phase>
-                                <goals>
-                                    <goal>cobertura</goal>
-                                </goals>
-                                <configuration>
-                                    <format>xml</format>
-                                    <maxmem>256m</maxmem>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.eluder.coveralls</groupId>
-                        <artifactId>coveralls-maven-plugin</artifactId>
-                        <version>4.1.0</version>
-                        <executions>
-                            <execution>
-                                <phase>site</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                                <configuration>
-                                    <repoToken>${coveralls.token}</repoToken>
-                                    <sourceDirectories>
-                                        <dir>${project.build.directory}/generated-sources/antlr3</dir>
-                                    </sourceDirectories>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/src/main/java/org/xembly/XpathDirective.java
+++ b/src/main/java/org/xembly/XpathDirective.java
@@ -58,7 +58,13 @@ final class XpathDirective implements Directive {
     /**
      * XPath factory.
      */
-    private static final XPathFactory FACTORY = XPathFactory.newInstance();
+    private static final ThreadLocal<XPathFactory> FACTORY =
+        new ThreadLocal<XPathFactory>() {
+            @Override
+            protected XPathFactory initialValue() {
+                return XPathFactory.newInstance();
+            }
+        };
 
     /**
      * Pattern to match root-only XPath queries.
@@ -135,7 +141,7 @@ final class XpathDirective implements Directive {
     private static Collection<Node> traditional(final String query,
         final Node dom, final Collection<Node> current)
         throws ImpossibleModificationException {
-        final XPath xpath = XpathDirective.FACTORY.newXPath();
+        final XPath xpath = XpathDirective.FACTORY.get().newXPath();
         final Collection<Node> targets = new HashSet<Node>(0);
         for (final Node node : XpathDirective.roots(dom, current)) {
             final NodeList list;


### PR DESCRIPTION
#82: Moved `XpathFactory` into a `ThreadLocal` to ensure that `XpathDirective` really _is_ thread safe. This is necessary because [`XpathFactory`](https://docs.oracle.com/javase/7/docs/api/javax/xml/xpath/XPathFactory.html) is **not** thread safe.