### PR TITLE
Can parse with new lines and spaces after last command

### DIFF
--- a/src/main/java/org/xembly/Verbs.java
+++ b/src/main/java/org/xembly/Verbs.java
@@ -106,12 +106,13 @@ final class Verbs {
      * @return Directives from text
      */
     public Iterable<Directive> directives() {
-        if (!this.text.trim().isEmpty()) {
+        final String trimmed = this.text.trim();
+        if (!trimmed.isEmpty()) {
             final String semicolon = ";";
             final StringBuilder builder = new StringBuilder();
             Optional<Callback<Directive>> command;
             try {
-                for (final String part : this.text.split(semicolon)) {
+                for (final String part : trimmed.split(semicolon)) {
                     if (builder.length() == 0) {
                         builder.append(Verbs.ltrim(part));
                     } else {

--- a/src/test/java/org/xembly/VerbsTest.java
+++ b/src/test/java/org/xembly/VerbsTest.java
@@ -52,4 +52,22 @@ final class VerbsTest {
             Matchers.containsString("near [broken;]")
         );
     }
+
+    @Test
+    void worksWithSpacesAfterLastCommand() {
+        Assertions.assertDoesNotThrow(
+            () -> new Xembler(
+                new Directives("ADD 'o'; ATTR 'base', 'int';    ")
+            ).xml()
+        );
+    }
+
+    @Test
+    void worksWithNewLines() {
+        Assertions.assertDoesNotThrow(
+            () -> new Xembler(
+                new Directives("\n\nADD 'o';\nATTR 'base','int';\n\n")
+            ).xml()
+        );
+    }
 }

--- a/src/test/java/org/xembly/prof/DirectivesProfTest.java
+++ b/src/test/java/org/xembly/prof/DirectivesProfTest.java
@@ -55,5 +55,4 @@ final class DirectivesProfTest {
         final Directives dirs = new Directives(program.toString());
         MatcherAssert.assertThat(dirs, Matchers.notNullValue());
     }
-
 }

--- a/src/test/java/org/xembly/prof/XemblerProfTest.java
+++ b/src/test/java/org/xembly/prof/XemblerProfTest.java
@@ -65,5 +65,4 @@ final class XemblerProfTest {
             XhtmlMatchers.hasXPath("/root/node[.='49999']")
         );
     }
-
 }


### PR DESCRIPTION
[This PR](https://github.com/objectionary/eo/pull/2767) is failed because Xembly is unable to parse directives with spaces and new lines after last command. Fixed it