### PR TITLE
#53 add Transformers.Standalone to control the standalone attribute

### DIFF
--- a/src/main/java/org/xembly/Transformers.java
+++ b/src/main/java/org/xembly/Transformers.java
@@ -85,6 +85,58 @@ public interface Transformers {
     }
 
     /**
+     * Transformer factory that emits an explicit {@code standalone}
+     * attribute in the XML declaration.
+     * Pass {@code true} to emit {@code standalone="yes"} or {@code false} to
+     * emit {@code standalone="no"}. Indentation and UTF-8 encoding are kept
+     * to match {@link Transformers.Document}.
+     * @since 0.33
+     */
+    final class Standalone implements Transformers {
+
+        /**
+         * Original transformer factory.
+         */
+        private final Transformers original;
+
+        /**
+         * Public ctor.
+         * @param standalone Whether the document is standalone
+         * @since 0.33
+         */
+        public Standalone(final boolean standalone) {
+            this.original = new Transformers.Formatted(
+                new Transformers.Default(),
+                Transformers.Standalone.props(standalone)
+            );
+        }
+
+        @Override
+        public Transformer create() {
+            return this.original.create();
+        }
+
+        /**
+         * Build output properties for the given standalone value.
+         * @param standalone Whether the document is standalone
+         * @return Properties to configure the output
+         */
+        private static Map<String, String> props(final boolean standalone) {
+            final Map<String, String> res = new HashMap<>();
+            res.put(OutputKeys.INDENT, "yes");
+            res.put(OutputKeys.ENCODING, "UTF-8");
+            final String value;
+            if (standalone) {
+                value = "yes";
+            } else {
+                value = "no";
+            }
+            res.put(OutputKeys.STANDALONE, value);
+            return res;
+        }
+    }
+
+    /**
      * Transformer factory that produces document transformers.
      * All transformers produced by this factory will be configured to produce
      * XML documents with XML declaration and indentation.

--- a/src/test/java/org/xembly/TransformersTest.java
+++ b/src/test/java/org/xembly/TransformersTest.java
@@ -65,4 +65,28 @@ final class TransformersTest {
             Matchers.not(Matchers.containsString("<?xml"))
         );
     }
+
+    @Test
+    void rendersStandaloneNoInDeclaration() throws Exception {
+        MatcherAssert.assertThat(
+            "Standalone(false) must emit standalone=\"no\"",
+            new Xembler(
+                new Directives().add("page"),
+                new Transformers.Standalone(false)
+            ).xml(),
+            Matchers.containsString("standalone=\"no\"")
+        );
+    }
+
+    @Test
+    void rendersStandaloneYesInDeclaration() throws Exception {
+        MatcherAssert.assertThat(
+            "Standalone(true) must emit standalone=\"yes\"",
+            new Xembler(
+                new Directives().add("page"),
+                new Transformers.Standalone(true)
+            ).xml(),
+            Matchers.containsString("standalone=\"yes\"")
+        );
+    }
 }


### PR DESCRIPTION
Adds a `Transformers.Standalone` factory so callers can ask the XML output to carry an explicit `standalone="yes"` or `standalone="no"` in the declaration. Until now neither `Transformers.Document` nor `Transformers.Compact` exposed that attribute, so the scenario from #53 (`<?xml version="1.0" encoding="UTF-8" standalone="no"?>`) was unreachable through the public API.

`new Xembler(directives, new Transformers.Standalone(false)).xml()` now produces a declaration with `standalone="no"`, and `Standalone(true)` produces `standalone="yes"`. Indentation and UTF-8 encoding match `Transformers.Document` so the rest of the output is unchanged.

Verified locally with `mvn -Pqulice -Dhone.skip=true clean install`: the build is green, Qulice has no violations, and the two new cases in `TransformersTest` pass alongside the existing six tests.

Closes #53